### PR TITLE
Depend on libgtk-3-0 | libgtk2.0-0, don't require both

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -57,6 +57,17 @@ binary: binary-arch binary-indep ;
 override_dh_compress:
 	dh_compress --exclude=.c --exclude=.mk
 
+override_dh_gencontrol:
+	set -ex; \
+	if [ -f debian/nvidia-settings.substvars ]; then \
+		sed -ri -e 's/(^[^:]*:Depends=)/\1 GTK3 | GTK2, /' \
+			-e 's/(GTK2)(.*)(libgtk2.0-0 \([^\)]*\))/\3\2/' \
+			-e 's/(GTK3)(.*)(libgtk-3-0 \([^\)]*\))/\3\2/' \
+			debian/nvidia-settings.substvars ; \
+		! grep GTK debian/nvidia-settings.substvars ; \
+	fi
+	dh_gencontrol
+
 override_dh_installexamples:
 	dh_installexamples -X"_out" -a
 


### PR DESCRIPTION
Adapted from:
https://anonscm.debian.org/cgit/pkg-nvidia/nvidia-settings.git/commit/?id=ea169261264f7d8b80e3e091a131cb98343e7d3f
https://bugs.launchpad.net/ubuntu/+source/nvidia-settings/+bug/1736617
LP: #1736617