### PR TITLE
Do not build the nvidia-settings binary package on i386 in Ubuntu

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+nvidia-settings (440.44-0ubuntu2) UNRELEASED; urgency=medium
+
+  * Do not build the nvidia-settings binary package on i386 in Ubuntu, since
+    it wil not be installable.
+
+ -- Steve Langasek <steve.langasek@ubuntu.com>  Tue, 22 Sep 2020 01:33:41 -0700
+
 nvidia-settings (440.44-0ubuntu1) focal; urgency=medium
 
   * New upstream release.

--- a/debian/rules
+++ b/debian/rules
@@ -9,7 +9,7 @@ DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 export NV_USE_BUNDLED_LIBJANSSON = 0
 
 ifeq ($(shell dpkg-vendor --is Ubuntu && echo yes) $(DEB_HOST_ARCH), yes i386)
-   skip_packages = -Nbluez-cups
+   skip_packages = -Nnvidia-settings
 endif
 
 build: build-arch

--- a/debian/rules
+++ b/debian/rules
@@ -8,6 +8,10 @@ DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 
 export NV_USE_BUNDLED_LIBJANSSON = 0
 
+ifeq ($(shell dpkg-vendor --is Ubuntu && echo yes) $(DEB_HOST_ARCH), yes i386)
+   skip_packages = -Nbluez-cups
+endif
+
 build: build-arch
 build-arch:
 	$(MAKE) -C src/libXNVCtrl EXTINCSRC=/usr/include/X11/extensions \
@@ -58,6 +62,12 @@ override_dh_auto_install:
 
 override_dh_usrlocal:
 	rm -Rf $(CURDIR)/debian/$(PKG_name)/usr/local
+
+override_dh_builddeb:
+	dh_builddeb $(skip_packages)
+
+override_dh_gencontrol:
+	dh_gencontrol $(skip_packages)
 
 %:
 	dh $@


### PR DESCRIPTION
Since i386 is a partial arch in Ubuntu for focal and later, this binary package will not be installable, therefore we should not build it.