### PR TITLE
Rename 'powersaving' mode to iGPU from intel

### DIFF
--- a/debian/patches/20_Rename-the-UI-from-Intel-to-iGPU.patch
+++ b/debian/patches/20_Rename-the-UI-from-Intel-to-iGPU.patch
@@ -1,0 +1,71 @@
+From: Jeremy Szu <jeremy.szu@canonical.com>
+Date: Mon, 15 Aug 2022 06:32:34 +0000
+Subject: Rename the UI from Intel to iGPU
+
+1. Some A+N platforms will confuse the intel settings.
+2. leave prime action as Intel to make sure the API is working before
+   changing the nvidia-prime.
+---
+ src/gtk+-2.x/ctkprime.c | 18 +++++++++---------
+ 1 file changed, 9 insertions(+), 9 deletions(-)
+
+diff --git a/src/gtk+-2.x/ctkprime.c b/src/gtk+-2.x/ctkprime.c
+index 67ee29f..c803c47 100644
+--- a/src/gtk+-2.x/ctkprime.c
++++ b/src/gtk+-2.x/ctkprime.c
+@@ -311,10 +311,10 @@ prime_update_radio_buttons(CtkPrime *ctk_prime, gint value)
+  *   if ctk_prime->has_on_demand_mode == 1:
+  *     nvidia: 0
+  *     on-demand: 1
+- *     intel: 2 # presents but disabled for if user issues "prime-select intel"
++ *     iGPU: 2 # presents but disabled for if user issues "prime-select intel"
+  *   else:
+  *     nvidia: 0
+- *     intel: 1
++ *     iGPU: 1
+  */
+ static int mode_to_button_value(CtkPrime *ctk_prime, gchar *current_gpu) {
+     int current_button;
+@@ -570,13 +570,13 @@ GtkWidget* ctk_prime_new(CtkConfig *ctk_config)
+                                "performance mode). This option is applied after "
+                                "a system restart.");
+ 
+-        /* Button for Intel */
++        /* Button for iGPU */
+         radio[2] = prime_radio_button_add(ctk_prime,
+                                           radio[1],
+-                                          "Intel (Power Saving Mode)",
++                                          "iGPU (Power Saving Mode)",
+                                           "intel",
+                                           2);
+-        /* Set the tooltip for Intel */
++        /* Set the tooltip for iGPU*/
+         ctk_config_set_tooltip(ctk_config, radio[2],
+                                "Enabling this option ensures the best "
+                                "battery life. This option is "
+@@ -584,13 +584,13 @@ GtkWidget* ctk_prime_new(CtkConfig *ctk_config)
+ 
+ 	gtk_widget_set_sensitive(radio[2], FALSE);
+     } else {
+-        /* Button for Intel */
++        /* Button for iGPU */
+         radio[1] = prime_radio_button_add(ctk_prime,
+                                           radio[0],
+-                                          "Intel (Power Saving Mode)",
++                                          "iGPU (Power Saving Mode)",
+                                           "intel",
+                                           1);
+-        /* Set the tooltip for Intel */
++        /* Set the tooltip for iGPU*/
+         ctk_config_set_tooltip(ctk_config, radio[1],
+                                "Enabling this option ensures the best "
+                                "battery life. This option is "
+@@ -639,7 +639,7 @@ GtkTextBuffer *ctk_prime_create_help(GtkTextTagTable *table,
+ 
+     ctk_help_para(b, &i, "It is recommended that you "
+                          "select NVIDIA for the best performance, "
+-                         "and Intel for the best battery life.");
++                         "and iGPU for the best battery life.");
+ 
+     ctk_help_finish(b);
+ 

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -12,3 +12,4 @@ include-Xlib.patch
 17_do_not_read_config_on_power_saving_mode.patch
 18_remove_power-saving_if_on-demand.patch
 19_lp1957094-adjust-on-demand-mode-description.patch
+20_Rename-the-UI-from-Intel-to-iGPU.patch


### PR DESCRIPTION
1. Some A+N platforms have nvidia-settings be installed and
   nvidia-settings shows 'intel' as powersaving mode item, which makes
   users confused. Rename is as iGPU. (LP: #1982472)
2. Some parts need to change together if nvidia-prime wants to adjust as
   well but it relates a lot of components. Thus, fix the UI first for
   most of users.